### PR TITLE
docs: Add JPEG-XL support information

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ or
 - MuPDF (version 1.15 or higher)
 
 ### Optional Features
-- libdbus, libjpeg, libpng, libtiff, libexif devel files for various format supports
+- libdbus, libjpeg, libpng, libtiff, libexif, libjxl devel files for various format supports
 - Dejavu Sans fonts for internal test suite
 
 ### Compiler and Make Tools
@@ -98,9 +98,9 @@ make check
   ```
   sudo apt-get install ghostscript
   ```
-- Install optional libraries (libdbus, libjpeg, libpng, libtiff, libexif):
+- Install optional libraries (libdbus, libjpeg, libpng, libtiff, libexif, libjxl):
   ```
-  sudo apt-get install libdbus-1-dev libjpeg-dev libpng-dev libtiff-dev libexif-dev
+  sudo apt-get install libdbus-1-dev libjpeg-dev libpng-dev libtiff-dev libexif-dev libjxl-dev
   ```
 - Install Dejavu Sans fonts (for internal test suite):
   ```
@@ -120,9 +120,9 @@ make check
   ```
   sudo dnf install ghostscript
   ```
-- Install optional libraries (libdbus, libjpeg, libpng, libtiff, libexif):
+- Install optional libraries (libdbus, libjpeg, libpng, libtiff, libexif, libjxl):
   ```
-  sudo dnf install dbus-devel libjpeg-turbo-devel libpng-devel libtiff-devel libexif-devel
+  sudo dnf install dbus-devel libjpeg-turbo-devel libpng-devel libtiff-devel libexif-devel libjxl-devel
   ```
 - Install Dejavu Sans fonts (for internal test suite):
   ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ make/model/device ID matching, ...
 
 For compiling and using this package see the INSTALL file.
 
+JPEG-XL support is optionally available. It is activated if the JPEG-XL
+library (libjxl) and its header files are installed when building
+libcupsfilters.
+
 Report bugs to
 
     https://github.com/OpenPrinting/libcupsfilters/issues


### PR DESCRIPTION
Added information about the optional JPEG-XL support to README.md and INSTALL.md.

This includes:
- Mentioning the dependency on libjxl.
- Instructions for installing the library on Debian/Ubuntu and Red Hat/Fedora systems.